### PR TITLE
adding default return to return all the dataTypes

### DIFF
--- a/src/main/java/life/genny/qwandautils/MergeUtil.java
+++ b/src/main/java/life/genny/qwandautils/MergeUtil.java
@@ -148,7 +148,8 @@ public class MergeUtil {
 							}
 						} else if(attributeValue instanceof java.lang.String){
 							return getBaseEntityAttrValueAsString(be, attributeCode);
-						}else {
+						}
+						else {
 							return getBaseEntityAttrValueAsString(be, attributeCode);
 						}
 						

--- a/src/main/java/life/genny/qwandautils/MergeUtil.java
+++ b/src/main/java/life/genny/qwandautils/MergeUtil.java
@@ -148,6 +148,8 @@ public class MergeUtil {
 							}
 						} else if(attributeValue instanceof java.lang.String){
 							return getBaseEntityAttrValueAsString(be, attributeCode);
+						}else {
+							return getBaseEntityAttrValueAsString(be, attributeCode);
 						}
 						
 					}


### PR DESCRIPTION
Currently, wordMerge() was returning value of the attribute only if its data type is Money, DateTime and  String.