### PR TITLE
fixing aws dependency issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
 		<jackson.version>2.9.5</jackson.version>
 		<version.mysql-connector>6.0.6</version.mysql-connector>
 		<jersey-version>2.13</jersey-version>
-		<version.apache-httpclient>4.5.5</version.apache-httpclient>
+		<version.apache-httpclient>4.5.3</version.apache-httpclient>
 		<version.keycloak>3.4.0.Final</version.keycloak>
 
 		<keycloak-core.version>3.4.0.Final</keycloak-core.version>


### PR DESCRIPTION
Fixed aws dependency consistency issue in 2 projects : 
1) Qwanda_Utils
2) Genny-rules
PR given in both services.

In Qwanda-utils, I downgraded the version of "apache-httpclient" to maintain consistency of the same dependency in wildfly-qwanda-service.

