### PR TITLE
fix the generation of the service token

### DIFF
--- a/.project
+++ b/.project
@@ -2,7 +2,9 @@
 <projectDescription>
   <name>qwanda-utils</name>
   <comment>Question and Answer Engine Utilities. NO_M2ECLIPSE_SUPPORT: Project files created with the maven-eclipse-plugin are not supported in M2Eclipse.</comment>
-  <projects/>
+  <projects>
+    <project>qwanda</project>
+  </projects>
   <buildSpec>
     <buildCommand>
       <name>org.eclipse.wst.common.project.facet.core.builder</name>
@@ -11,13 +13,13 @@
       <name>org.eclipse.jdt.core.javabuilder</name>
     </buildCommand>
     <buildCommand>
-      <name>org.eclipse.m2e.core.maven2Builder</name>
-    </buildCommand>
-    <buildCommand>
       <name>org.eclipse.wst.validation.validationbuilder</name>
     </buildCommand>
     <buildCommand>
       <name>org.zeroturnaround.eclipse.rebelXmlBuilder</name>
+    </buildCommand>
+    <buildCommand>
+      <name>org.eclipse.m2e.core.maven2Builder</name>
     </buildCommand>
   </buildSpec>
   <natures>

--- a/src/main/java/life/genny/qwandautils/KeycloakUtils.java
+++ b/src/main/java/life/genny/qwandautils/KeycloakUtils.java
@@ -76,7 +76,7 @@ public class KeycloakUtils {
 		
     try {
     	
-    		JsonObject content = KeycloakUtils.getAccessToken(keycloakUrl, realm, clientId, secret, username, password);
+    		JsonObject content = KeycloakUtils.getToken(keycloakUrl, realm, clientId, secret, username, password);
     		if(content != null) {
     			return content.getString("access_token");
     		}
@@ -92,7 +92,7 @@ public class KeycloakUtils {
 	public static AccessTokenResponse getAccessTokenResponse(String keycloakUrl, String realm, String clientId, String secret,
 			String username, String password) throws IOException {
 
-		JsonObject content = KeycloakUtils.getAccessToken(keycloakUrl, realm, clientId, secret, username, password);
+		JsonObject content = KeycloakUtils.getSecureTokenPayload(keycloakUrl, realm, clientId, secret, username, password);
 		if(content != null) {
 			return JsonUtils.fromJson(content.toString(), AccessTokenResponse.class);
 		}
@@ -107,6 +107,10 @@ public class KeycloakUtils {
 		secureTokenPayload.put("access_token", fullTokenPayload.getString("access_token"));
 		secureTokenPayload.put("refresh_token", fullTokenPayload.getString("refresh_token"));
 		return secureTokenPayload;
+	}
+
+	public static JsonObject getSecureTokenPayload(String keycloakUrl, String realm, String clientId, String secret, String username, String password) throws IOException {
+		return KeycloakUtils.getSecureTokenPayload(keycloakUrl, realm, clientId, secret, username, password, null);
 	}
 
 	public static JsonObject getToken(String keycloakUrl, String realm, String clientId, String secret, String username, String password, String refreshToken) throws IOException {
@@ -574,7 +578,7 @@ public class KeycloakUtils {
 //					+ "keycloakurl: " + keycloakurl + "\n" + "key : " + key + "\n" + "initVector : " + initVector + "\n"
 //					+ "enc pw : " + encryptedPassword + "\n" + "password : " + password + "\n");
 
-			String token = KeycloakUtils.getToken(keycloakUrl, realm, realm, secret, "service", password);
+			String token = KeycloakUtils.getAccessToken(keycloakUrl, realm, realm, secret, "service", password);
 //			println("token = " + token);
 			return token;
 


### PR DESCRIPTION
Issue: https://outcomelife.atlassian.net/browse/GEN-1391

Bug Description:
It looks like the service token was grabbed from the cache before. This was to prevent having to create a new session every time, but it is actually creating lots of issues as the service token is not refreshed when it needs to be. This is a rollback to creating a new session every time for now.

How To Test:
On internmatch, try to create a new internship. Most of the dropdowns with multiple selections will be empty. that's because the backend rules use the SearchEntity to get the relevant data using the service token. because the service token has expired, no data is showing in the dropdown.
