### PR TITLE
Added fix for issue with normalised username

### DIFF
--- a/src/main/java/life/genny/qwandautils/QwandaUtils.java
+++ b/src/main/java/life/genny/qwandautils/QwandaUtils.java
@@ -336,7 +336,7 @@ public class QwandaUtils {
 		if (rawUsername==null) {
 			return null;
 		}
-		return rawUsername.replaceAll("\\&", "_AND_").replaceAll("@", "_AT_").replaceAll("\\.", "")
+		return rawUsername.replaceAll("\\&", "_AND_").replaceAll("@", "_AT_").replaceAll("\\.", "_DOT_")
 				.replaceAll("\\+", "_PLUS_").toUpperCase();
 	}
 


### PR DESCRIPTION
**Note:** I've purposely left out details in this PR due to the severity of this issue.

**This is a breaking change!** 

Any users with full stops in their email addresses will end up logging in to a different profile, and won't be able to access their existing accounts.

Ideally we need a database migration to be performed to prevent this behaviour.